### PR TITLE
Add outlier detection and related functions

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -17,6 +17,20 @@ Peptide
    peptide
 
 
+Vetting
+-------
+
+.. autosummary::
+
+   OutlierResult
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   vetting
+
+
 Descriptors
 -----------
 

--- a/docs/api/vetting.rst
+++ b/docs/api/vetting.rst
@@ -1,0 +1,164 @@
+Sequence Vetting Functions
+==========================
+
+.. currentmodule:: peptides
+
+The sequence vetting functions provide tools for analyzing the complexity of protein sequences. These functions are particularly useful for quality control.
+
+Entropy
+-------
+
+.. autofunction:: peptides.Peptide.entropy
+
+The Shannon entropy measures the diversity of amino acids in a peptide sequence. It is calculated using the formula:
+
+.. math::
+
+    H = -\\sum_{i=1}^{n} p_i \\log_2(p_i)
+
+where :math:`p_i` is the frequency of amino acid :math:`i` and :math:`n` is the number of possible amino acids (26, including ambiguous codes).
+
+**Examples:**
+
+.. code-block:: python
+
+    from peptides import Peptide
+    
+    # Single amino acid sequence (minimum entropy)
+    peptide = Peptide("AAAA")
+    print(peptide.entropy())  # Output: 0.0
+    
+    # Diverse sequence (high entropy)
+    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
+    print(peptide.entropy())  # Output: ~4.32
+    
+    # Mixed sequence
+    peptide = Peptide("AALS")
+    print(peptide.entropy())  # Output: 1.5
+
+**Interpretation:** Most values fall between 3.71 and 4.18 bits for SwissProt data.
+**Range:** 0.0 to log₂(26) ≈ 4.70 bits
+
+Max Frequency
+-------------
+
+.. autofunction:: peptides.Peptide.max_frequency
+
+The maximum frequency identifies the amino acid that appears most frequently in the sequence and returns its frequency. This metric is useful for identifying dominant amino acids and assessing sequence diversity.
+
+**Examples:**
+
+.. code-block:: python
+
+    from peptides import Peptide
+    
+    # Single amino acid sequence
+    peptide = Peptide("AAAA")
+    print(peptide.max_frequency())  # Output: 1.0
+    
+    # Two amino acids with equal frequency
+    peptide = Peptide("AALS")
+    print(peptide.max_frequency())  # Output: 0.5
+    
+    # Diverse sequence
+    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
+    print(peptide.max_frequency())  # Output: 0.05
+
+**Interpretation:** Most values fall between 0.085 and 0.172 for SwissProt data.
+**Range:** 1/sequence_length to 1.0
+
+Longest Run
+-----------
+
+.. autofunction:: peptides.Peptide.longest_run
+
+The longest run identifies the length of the longest stretch of consecutive identical amino acids. This metric is useful for detecting repetitive regions, low complexity sequences, and potential sequencing artifacts.
+
+**Examples:**
+
+.. code-block:: python
+
+    from peptides import Peptide
+    
+    # Single amino acid sequence
+    peptide = Peptide("AAAA")
+    print(peptide.longest_run())  # Output: 4
+    
+    # Mixed sequence with runs
+    peptide = Peptide("AALLLSSS")
+    print(peptide.longest_run())  # Output: 3
+    
+    # No consecutive identical amino acids
+    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
+    print(peptide.longest_run())  # Output: 1
+
+**Interpretation:** Most values fall between 2 and 5 for SwissProt data.
+**Range:** 1 to sequence_length
+
+Outlier Detection
+----------------
+
+.. autofunction:: peptides.Peptide.detect_outlier
+
+The outlier detection function analyzes a peptide sequence using composition-based vetting metrics and compares them against established SwissProt protein distributions to identify potential outliers, artifacts, or unusual sequences. This function provides an automated way to flag sequences that may require further investigation.
+
+**How it works:**
+
+The function evaluates the following metrics against 5th and 95th percentile thresholds derived from SwissProt protein analysis:
+
+1. **Entropy**: Shannon entropy of amino acid composition
+2. **Max Frequency**: Maximum frequency of any single amino acid
+3. **Longest Run**: Length of longest consecutive identical amino acids
+
+Note: The result also returns the sequence length in the `metrics` field for reference, but it is not used to determine outliers.
+
+**Examples:**
+
+.. code-block:: python
+
+    from peptides import Peptide
+    
+    # Normal protein sequence
+    normal_peptide = Peptide("MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQAPILSRVGDGTQDNLSGAEKAVQVKVKALPDAQFEVVHSLAKWKRQTLGQHDFSAGEGLYTHMKALRPDEDRLSPLHSVYVDQWDWERVMGDGERQFSTLKSTVEAIWAGIKATEAAVSEEFGLAPFLPDQIHFVHSQELLSRYPDLDAKGRERAIAKDLGAVFLVGIGGKLSDGHRHDVRAPDYDDWUAIGLNKALELVKQKLKELN")
+    result = normal_peptide.detect_outlier()
+    print(f"Is outlier: {result['is_outlier']}")  # Output: False
+    print(f"Issues: {result['issues']}")          # Output: []
+    
+    # Problematic sequence
+    problematic_peptide = Peptide("AAAA")
+    result = problematic_peptide.detect_outlier()
+    print(f"Is outlier: {result['is_outlier']}")  # Output: True
+    print(f"Issues: {result['issues']}")          # Output: ['Entropy 0.000 below 5th percentile (3.714)', 'Max frequency 1.000 above 95th percentile (0.172)']
+
+**Return Value:**
+
+The function returns a dictionary with three keys:
+
+- **is_outlier**: Boolean indicating if the sequence is flagged as an outlier
+- **issues**: List of specific problems found (empty if no issues)
+- **metrics**: Dictionary containing the calculated values for all four metrics
+
+**Thresholds (based on SwissProt analysis):**
+
+- **Entropy**: 5th percentile = 3.714, 95th percentile = 4.185
+- **Max Frequency**: 5th percentile = 0.085, 95th percentile = 0.172
+- **Longest Run**: 5th percentile = 2.0, 95th percentile = 5.0
+
+**Use Cases:**
+
+1. **Quality Control**: Automatically flag problematic sequences in large datasets
+2. **Sequence Validation**: Ensure sequences meet expected biological parameters
+3. **Artifact Detection**: Identify potential sequencing errors or contaminants
+4. **Database Filtering**: Remove or flag unusual sequences before analysis
+5. **Research Validation**: Verify sequence quality in experimental workflows
+
+**Best Practices:**
+
+- Use as part of automated quality control pipelines
+- Review flagged sequences manually to confirm issues
+- Consider context when interpreting results (some unusual sequences may be biologically valid)
+- Combine with other validation methods for comprehensive quality assessment
+
+**References:**
+
+- Shannon, C. E. (1948). *A Mathematical Theory of Communication*. Bell System Technical Journal, 27(3), 379-423.

--- a/docs/api/vetting.rst
+++ b/docs/api/vetting.rst
@@ -1,108 +1,23 @@
-Sequence Vetting Functions
-==========================
+Sequence Vetting
+================
 
 .. currentmodule:: peptides
 
-The sequence vetting functions provide tools for analyzing the complexity of protein sequences. These functions are particularly useful for quality control.
+The sequence vetting functions provide tools for analyzing the complexity of 
+protein sequences. These functions are particularly useful for quality control.
 
-Entropy
--------
-
-.. autofunction:: peptides.Peptide.entropy
-
-The Shannon entropy measures the diversity of amino acids in a peptide sequence. It is calculated using the formula:
-
-.. math::
-
-    H = -\\sum_{i=1}^{n} p_i \\log_2(p_i)
-
-where :math:`p_i` is the frequency of amino acid :math:`i` and :math:`n` is the number of possible amino acids (26, including ambiguous codes).
-
-**Examples:**
-
-.. code-block:: python
-
-    from peptides import Peptide
-    
-    # Single amino acid sequence (minimum entropy)
-    peptide = Peptide("AAAA")
-    print(peptide.entropy())  # Output: 0.0
-    
-    # Diverse sequence (high entropy)
-    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
-    print(peptide.entropy())  # Output: ~4.32
-    
-    # Mixed sequence
-    peptide = Peptide("AALS")
-    print(peptide.entropy())  # Output: 1.5
-
-**Interpretation:** Most values fall between 3.71 and 4.18 bits for SwissProt data.
-**Range:** 0.0 to log₂(26) ≈ 4.70 bits
-
-Max Frequency
--------------
-
-.. autofunction:: peptides.Peptide.max_frequency
-
-The maximum frequency identifies the amino acid that appears most frequently in the sequence and returns its frequency. This metric is useful for identifying dominant amino acids and assessing sequence diversity.
-
-**Examples:**
-
-.. code-block:: python
-
-    from peptides import Peptide
-    
-    # Single amino acid sequence
-    peptide = Peptide("AAAA")
-    print(peptide.max_frequency())  # Output: 1.0
-    
-    # Two amino acids with equal frequency
-    peptide = Peptide("AALS")
-    print(peptide.max_frequency())  # Output: 0.5
-    
-    # Diverse sequence
-    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
-    print(peptide.max_frequency())  # Output: 0.05
-
-**Interpretation:** Most values fall between 0.085 and 0.172 for SwissProt data.
-**Range:** 1/sequence_length to 1.0
-
-Longest Run
------------
-
-.. autofunction:: peptides.Peptide.longest_run
-
-The longest run identifies the length of the longest stretch of consecutive identical amino acids. This metric is useful for detecting repetitive regions, low complexity sequences, and potential sequencing artifacts.
-
-**Examples:**
-
-.. code-block:: python
-
-    from peptides import Peptide
-    
-    # Single amino acid sequence
-    peptide = Peptide("AAAA")
-    print(peptide.longest_run())  # Output: 4
-    
-    # Mixed sequence with runs
-    peptide = Peptide("AALLLSSS")
-    print(peptide.longest_run())  # Output: 3
-    
-    # No consecutive identical amino acids
-    peptide = Peptide("ACDEFGHIKLMNPQRSTVWY")
-    print(peptide.longest_run())  # Output: 1
-
-**Interpretation:** Most values fall between 2 and 5 for SwissProt data.
-**Range:** 1 to sequence_length
 
 Outlier Detection
-----------------
+-----------------
 
-.. autofunction:: peptides.Peptide.detect_outlier
+The outlier detection function (`Peptide.detect_outlier`) analyzes a peptide 
+sequence using composition-based vetting metrics and compares them against 
+established SwissProt protein distributions to identify potential outliers, 
+artifacts, or unusual sequences. This function provides an automated way to 
+flag sequences that may require further investigation.
 
-The outlier detection function analyzes a peptide sequence using composition-based vetting metrics and compares them against established SwissProt protein distributions to identify potential outliers, artifacts, or unusual sequences. This function provides an automated way to flag sequences that may require further investigation.
-
-**How it works:**
+How it works
+^^^^^^^^^^^^
 
 The function evaluates the following metrics against 5th and 95th percentile thresholds derived from SwissProt protein analysis:
 
@@ -110,55 +25,24 @@ The function evaluates the following metrics against 5th and 95th percentile thr
 2. **Max Frequency**: Maximum frequency of any single amino acid
 3. **Longest Run**: Length of longest consecutive identical amino acids
 
-Note: The result also returns the sequence length in the `metrics` field for reference, but it is not used to determine outliers.
+Use Cases
+^^^^^^^^^
 
-**Examples:**
+1. **Quality Control**: Automatically flag problematic sequences in large datasets.
+2. **Sequence Validation**: Ensure sequences meet expected biological parameters.
+3. **Artifact Detection**: Identify potential sequencing errors or contaminants.
+4. **Database Filtering**: Remove or flag unusual sequences before analysis.
+5. **Research Validation**: Verify sequence quality in experimental workflows.
 
-.. code-block:: python
+Best Practices
+^^^^^^^^^^^^^^
 
-    from peptides import Peptide
-    
-    # Normal protein sequence
-    normal_peptide = Peptide("MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQAPILSRVGDGTQDNLSGAEKAVQVKVKALPDAQFEVVHSLAKWKRQTLGQHDFSAGEGLYTHMKALRPDEDRLSPLHSVYVDQWDWERVMGDGERQFSTLKSTVEAIWAGIKATEAAVSEEFGLAPFLPDQIHFVHSQELLSRYPDLDAKGRERAIAKDLGAVFLVGIGGKLSDGHRHDVRAPDYDDWUAIGLNKALELVKQKLKELN")
-    result = normal_peptide.detect_outlier()
-    print(f"Is outlier: {result['is_outlier']}")  # Output: False
-    print(f"Issues: {result['issues']}")          # Output: []
-    
-    # Problematic sequence
-    problematic_peptide = Peptide("AAAA")
-    result = problematic_peptide.detect_outlier()
-    print(f"Is outlier: {result['is_outlier']}")  # Output: True
-    print(f"Issues: {result['issues']}")          # Output: ['Entropy 0.000 below 5th percentile (3.714)', 'Max frequency 1.000 above 95th percentile (0.172)']
+- Use as part of automated quality control pipelines.
+- Review flagged sequences manually to confirm issues.
+- Consider context when interpreting results (some unusual sequences may be biologically valid).
+- Combine with other validation methods for comprehensive quality assessment.
 
-**Return Value:**
+Result
+^^^^^^
 
-The function returns a dictionary with three keys:
-
-- **is_outlier**: Boolean indicating if the sequence is flagged as an outlier
-- **issues**: List of specific problems found (empty if no issues)
-- **metrics**: Dictionary containing the calculated values for all four metrics
-
-**Thresholds (based on SwissProt analysis):**
-
-- **Entropy**: 5th percentile = 3.714, 95th percentile = 4.185
-- **Max Frequency**: 5th percentile = 0.085, 95th percentile = 0.172
-- **Longest Run**: 5th percentile = 2.0, 95th percentile = 5.0
-
-**Use Cases:**
-
-1. **Quality Control**: Automatically flag problematic sequences in large datasets
-2. **Sequence Validation**: Ensure sequences meet expected biological parameters
-3. **Artifact Detection**: Identify potential sequencing errors or contaminants
-4. **Database Filtering**: Remove or flag unusual sequences before analysis
-5. **Research Validation**: Verify sequence quality in experimental workflows
-
-**Best Practices:**
-
-- Use as part of automated quality control pipelines
-- Review flagged sequences manually to confirm issues
-- Consider context when interpreting results (some unusual sequences may be biologically valid)
-- Combine with other validation methods for comprehensive quality assessment
-
-**References:**
-
-- Shannon, C. E. (1948). *A Mathematical Theory of Communication*. Bell System Technical Journal, 27(3), 379-423.
+.. autoclass:: peptides.OutlierResult(typing.NamedTuple)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,5 +193,6 @@ extlinks = {
     'pmc': ('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC%s', 'PMC%s'),
     'isbn': ('https://www.worldcat.org/isbn/%s', 'ISBN:%s'),
     'wiki': ('https://en.wikipedia.org/wiki/%s', '%s'),
-    'aaindex': ('https://www.genome.jp/entry/aaindex:%s', 'AAindex:%s')
+    'aaindex': ('https://www.genome.jp/entry/aaindex:%s', 'AAindex:%s'),
+    'uniprot': ('https://www.uniprot.org/uniprotkb/%s', 'UniProt:%s'),
 }

--- a/tests/test_sequence_vetting.py
+++ b/tests/test_sequence_vetting.py
@@ -1,0 +1,258 @@
+import unittest
+import math
+import peptides
+
+
+class TestSequenceVetting(unittest.TestCase):
+    """Test cases for the new sequence vetting functions: entropy, max_frequency, and longest_run."""
+
+    def test_entropy_basic(self):
+        """Test basic entropy calculations."""
+        # Single amino acid sequence (minimum entropy)
+        peptide1 = peptides.Peptide("AAAA")
+        self.assertEqual(peptide1.entropy(), 0.0)
+        
+        # Two amino acids with equal frequency
+        peptide2 = peptides.Peptide("AALS")
+        expected2 = -0.5 * math.log2(0.5) - 0.25 * math.log2(0.25) - 0.25 * math.log2(0.25)
+        self.assertAlmostEqual(peptide2.entropy(), expected2, places=10)
+        
+        # All 20 standard amino acids (maximum entropy for standard set)
+        peptide3 = peptides.Peptide("ACDEFGHIKLMNPQRSTVWY")
+        expected3 = math.log2(20)  # Maximum entropy for 20 equally frequent amino acids
+        self.assertAlmostEqual(peptide3.entropy(), expected3, places=10)
+
+    def test_entropy_edge_cases(self):
+        """Test entropy function with edge cases."""
+        # Empty sequence
+        peptide_empty = peptides.Peptide("")
+        self.assertEqual(peptide_empty.entropy(), 0.0)
+        
+        # Single amino acid
+        peptide_single = peptides.Peptide("A")
+        self.assertEqual(peptide_single.entropy(), 0.0)
+        
+        # Two identical amino acids
+        peptide_two = peptides.Peptide("AA")
+        self.assertEqual(peptide_two.entropy(), 0.0)
+
+    def test_entropy_diverse_sequences(self):
+        """Test entropy with diverse sequences."""
+        # Mixed sequence with known frequencies
+        peptide = peptides.Peptide("AALLLSSS")
+        # A: 2/8 = 0.25, L: 3/8 = 0.375, S: 3/8 = 0.375
+        expected = -0.25 * math.log2(0.25) - 0.375 * math.log2(0.375) - 0.375 * math.log2(0.375)
+        self.assertAlmostEqual(peptide.entropy(), expected, places=10)
+        
+        # Sequence with all 26 possible amino acid codes
+        peptide_full = peptides.Peptide("ACDEFGHIKLMNPQRSTVWYOUBZXJ")
+        # Each amino acid appears once, so frequency = 1/26
+        expected_full = math.log2(26)
+        self.assertAlmostEqual(peptide_full.entropy(), expected_full, places=10)
+
+    def test_max_frequency_basic(self):
+        """Test basic max_frequency calculations."""
+        # Single amino acid sequence
+        peptide1 = peptides.Peptide("AAAA")
+        self.assertEqual(peptide1.max_frequency(), 1.0)
+        
+        # Two amino acids with equal frequency
+        peptide2 = peptides.Peptide("AALS")
+        self.assertEqual(peptide2.max_frequency(), 0.5)
+        
+        # All 20 standard amino acids (equal frequency)
+        peptide3 = peptides.Peptide("ACDEFGHIKLMNPQRSTVWY")
+        self.assertEqual(peptide3.max_frequency(), 0.05)  # 1/20
+
+    def test_max_frequency_edge_cases(self):
+        """Test max_frequency function with edge cases."""
+        # Empty sequence
+        peptide_empty = peptides.Peptide("")
+        self.assertEqual(peptide_empty.max_frequency(), 0.0)
+        
+        # Single amino acid
+        peptide_single = peptides.Peptide("A")
+        self.assertEqual(peptide_single.max_frequency(), 1.0)
+        
+        # Two identical amino acids
+        peptide_two = peptides.Peptide("AA")
+        self.assertEqual(peptide_two.max_frequency(), 1.0)
+
+    def test_max_frequency_mixed_sequences(self):
+        """Test max_frequency with mixed sequences."""
+        # Mixed sequence with known frequencies
+        peptide = peptides.Peptide("AALLLSSS")
+        # A: 2/8 = 0.25, L: 3/8 = 0.375, S: 3/8 = 0.375
+        self.assertEqual(peptide.max_frequency(), 0.375)
+        
+        # Complex sequence
+        peptide_complex = peptides.Peptide("AAALLLSSSS")
+        # A: 3/10 = 0.3, L: 3/10 = 0.3, S: 4/10 = 0.4
+        self.assertEqual(peptide_complex.max_frequency(), 0.4)
+
+    def test_longest_run_basic(self):
+        """Test basic longest_run calculations."""
+        # Single amino acid sequence
+        peptide1 = peptides.Peptide("AAAA")
+        self.assertEqual(peptide1.longest_run(), 4)
+        
+        # Two amino acids with equal frequency
+        peptide2 = peptides.Peptide("AALS")
+        self.assertEqual(peptide2.longest_run(), 2)
+        
+        # All 20 standard amino acids (no runs)
+        peptide3 = peptides.Peptide("ACDEFGHIKLMNPQRSTVWY")
+        self.assertEqual(peptide3.longest_run(), 1)
+
+    def test_longest_run_edge_cases(self):
+        """Test longest_run function with edge cases."""
+        # Empty sequence
+        peptide_empty = peptides.Peptide("")
+        self.assertEqual(peptide_empty.longest_run(), 0)
+        
+        # Single amino acid
+        peptide_single = peptides.Peptide("A")
+        self.assertEqual(peptide_single.longest_run(), 1)
+        
+        # Two identical amino acids
+        peptide_two = peptides.Peptide("AA")
+        self.assertEqual(peptide_two.longest_run(), 2)
+
+    def test_longest_run_mixed_sequences(self):
+        """Test longest_run with mixed sequences."""
+        # Mixed sequence with known runs
+        peptide = peptides.Peptide("AALLLSSS")
+        self.assertEqual(peptide.longest_run(), 3)  # LLL
+        
+        # Complex sequence with multiple runs
+        peptide_complex = peptides.Peptide("AAALLLSSSS")
+        self.assertEqual(peptide_complex.longest_run(), 4)  # SSSS
+        
+        # Sequence with runs at different positions
+        peptide_positions = peptides.Peptide("LLAAASSLL")
+        self.assertEqual(peptide_positions.longest_run(), 3)  # AAA
+
+    def test_integration_all_functions(self):
+        """Test that all three functions work together correctly."""
+        peptide = peptides.Peptide("AALLLSSS")
+        
+        # Get all three metrics
+        entropy_val = peptide.entropy()
+        max_freq_val = peptide.max_frequency()
+        longest_run_val = peptide.longest_run()
+        
+        # Verify the values make sense together
+        self.assertGreaterEqual(entropy_val, 0.0)
+        self.assertLessEqual(entropy_val, math.log2(26))  # Maximum possible entropy
+        
+        self.assertGreaterEqual(max_freq_val, 0.125)  # 1/8 for this sequence
+        self.assertLessEqual(max_freq_val, 1.0)
+        
+        self.assertGreaterEqual(longest_run_val, 1)
+        self.assertLessEqual(longest_run_val, len(peptide.sequence))
+        
+        # Verify specific values for this sequence
+        self.assertAlmostEqual(entropy_val, 1.5613, places=3)
+        self.assertEqual(max_freq_val, 0.375)
+        self.assertEqual(longest_run_val, 3)
+
+    def test_entropy_max_frequency_relationship(self):
+        """Test the mathematical relationship between entropy and max_frequency."""
+        # Sequences with high max_frequency should have low entropy
+        peptide_high_freq = peptides.Peptide("AAAA")
+        self.assertEqual(peptide_high_freq.max_frequency(), 1.0)
+        self.assertEqual(peptide_high_freq.entropy(), 0.0)
+        
+        # Sequences with low max_frequency should have high entropy
+        peptide_low_freq = peptides.Peptide("ACDEFGHIKLMNPQRSTVWY")
+        self.assertEqual(peptide_low_freq.max_frequency(), 0.05)
+        self.assertAlmostEqual(peptide_low_freq.entropy(), math.log2(20), places=10)
+
+    def test_longest_run_independence(self):
+        """Test that longest_run is independent of overall frequencies."""
+        # These sequences have the same frequencies but different run patterns
+        peptide1 = peptides.Peptide("AALLLSSS")
+        peptide2 = peptides.Peptide("ALSLASLS")
+        
+        # Same frequencies and entropy
+        self.assertEqual(peptide1.frequencies(), peptide2.frequencies())
+        self.assertAlmostEqual(peptide1.entropy(), peptide2.entropy(), places=10)
+        self.assertEqual(peptide1.max_frequency(), peptide2.max_frequency())
+        
+        # But different longest runs
+        self.assertEqual(peptide1.longest_run(), 3)  # LLL
+        self.assertEqual(peptide2.longest_run(), 1)  # No runs
+
+    def test_real_protein_sequences(self):
+        """Test with real protein sequences."""
+        # Real protein sequence
+        real_protein = peptides.Peptide("MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQAPILSRVGDGTQDNLSGAEKAVQVKVKALPDAQFEVVHSLAKWKRQTLGQHDFSAGEGLYTHMKALRPDEDRLSPLHSVYVDQWDWERVMGDGERQFSTLKSTVEAIWAGIKATEAAVSEEFGLAPFLPDQIHFVHSQELLSRYPDLDAKGRERAIAKDLGAVFLVGIGGKLSDGHRHDVRAPDYDFEWHHFYTLIASRLAWNFKLGGK")
+        
+        # Verify all functions work with long sequences
+        entropy_val = real_protein.entropy()
+        max_freq_val = real_protein.max_frequency()
+        longest_run_val = real_protein.longest_run()
+        
+        # Check reasonable ranges
+        self.assertGreater(entropy_val, 3.0)  # Should be high for diverse protein
+        self.assertLess(entropy_val, 4.7)     # Less than maximum possible
+        self.assertGreater(max_freq_val, 0.01) # Some amino acids should be common
+        self.assertLess(max_freq_val, 0.2)     # But not dominant
+        self.assertGreaterEqual(longest_run_val, 1)  # At least 1
+        self.assertLessEqual(longest_run_val, 5)     # Reasonable upper bound for real proteins
+
+    def test_ambiguous_amino_acids(self):
+        """Test that functions work with ambiguous amino acid codes."""
+        # Sequence with ambiguous codes (B, Z, X, J, O, U)
+        peptide_ambig = peptides.Peptide("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+        
+        # All functions should work without errors
+        entropy_val = peptide_ambig.entropy()
+        max_freq_val = peptide_ambig.max_frequency()
+        longest_run_val = peptide_ambig.longest_run()
+        
+        # Verify reasonable values
+        self.assertGreater(entropy_val, 0.0)
+        self.assertLessEqual(entropy_val, math.log2(26))
+        self.assertEqual(max_freq_val, 1.0 / 26)  # Each amino acid appears once
+        self.assertEqual(longest_run_val, 1)       # No consecutive identical amino acids
+
+    def test_detect_outlier(self):
+        """Test the detect_outlier method."""
+        # Test with a normal sequence
+        normal_peptide = peptides.Peptide("MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQAPILSRVGDGTQDNLSGAEKAVQVKVKALPDAQFEVVHSLAKWKRQTLGQHDFSAGEGLYTHMKALRPDEDRLSPLHSVYVDQWDWERVMGDGERQFSTLKSTVEAIWAGIKATEAAVSEEFGLAPFLPDQIHFVHSQELLSRYPDLDAKGRERAIAKDLGAVFLVGIGGKLSDGHRHDVRAPDYDDWUAIGLNKALELVKQKLKELN")
+        
+        # This should work if distribution data exists
+        try:
+            result = normal_peptide.detect_outlier()
+            # Verify the result structure
+            self.assertIn('is_outlier', result)
+            self.assertIn('issues', result)
+            self.assertIn('metrics', result)
+            self.assertIsInstance(result['is_outlier'], bool)
+            self.assertIsInstance(result['issues'], list)
+            self.assertIsInstance(result['metrics'], dict)
+            
+            # Verify metrics are present
+            expected_metrics = ['entropy', 'max_frequency', 'longest_run', 'sequence_length']
+            for metric in expected_metrics:
+                self.assertIn(metric, result['metrics'])
+                
+        except FileNotFoundError:
+            # Skip test if distribution data not available
+            self.skipTest("SwissProt distribution data not available. Run generate_swissprot_distributions_for_vetting_functions.py first.")
+        
+        # Test with a clearly problematic sequence
+        problematic_peptide = peptides.Peptide("AAAA")
+        try:
+            result = problematic_peptide.detect_outlier()
+            # This should definitely be an outlier
+            self.assertTrue(result['is_outlier'])
+            self.assertGreater(len(result['issues']), 0)
+            
+        except FileNotFoundError:
+            self.skipTest("SwissProt distribution data not available.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sequence_vetting.py
+++ b/tests/test_sequence_vetting.py
@@ -226,17 +226,14 @@ class TestSequenceVetting(unittest.TestCase):
         try:
             result = normal_peptide.detect_outlier()
             # Verify the result structure
-            self.assertIn('is_outlier', result)
-            self.assertIn('issues', result)
-            self.assertIn('metrics', result)
-            self.assertIsInstance(result['is_outlier'], bool)
-            self.assertIsInstance(result['issues'], list)
-            self.assertIsInstance(result['metrics'], dict)
+            self.assertIsInstance(result.is_outlier, bool)
+            self.assertIsInstance(result.issues, list)
+            self.assertIsInstance(result.metrics, dict)
             
             # Verify metrics are present
             expected_metrics = ['entropy', 'max_frequency', 'longest_run', 'sequence_length']
             for metric in expected_metrics:
-                self.assertIn(metric, result['metrics'])
+                self.assertIn(metric, result.metrics)
                 
         except FileNotFoundError:
             # Skip test if distribution data not available
@@ -247,8 +244,8 @@ class TestSequenceVetting(unittest.TestCase):
         try:
             result = problematic_peptide.detect_outlier()
             # This should definitely be an outlier
-            self.assertTrue(result['is_outlier'])
-            self.assertGreater(len(result['issues']), 0)
+            self.assertTrue(result.is_outlier)
+            self.assertGreater(len(result.issues), 0)
             
         except FileNotFoundError:
             self.skipTest("SwissProt distribution data not available.")


### PR DESCRIPTION
Hi Martin,

Hope you are well! Nothing urgent here and thanks again for developing/porting another amazing tool. 

This pull request mainly introduces a function for outlier/abnormality detection of peptides and three helper functions which compute the maximum frequency of AAs in a peptide, the longest run of the same AA in a peptide, and the sequence entropy of the peptide using a consistent base, 26. The outlier detection function basically assesses whether any of these metrics are in the bottom or top 5% of values from systematic application to proteins in Swiss-Prot (downloaded on Aug 27, 2025).

<img width="4470" height="3543" alt="swissprot_vetting_distributions" src="https://github.com/user-attachments/assets/f80c154f-2273-42cb-bb6e-0dc73892de41" />

<img width="4746" height="3543" alt="swissprot_vetting_scatter_plots" src="https://github.com/user-attachments/assets/8122399a-620e-4822-90da-1506d03f2443" />

Saw retrospectively on the contributing doc that an "issue" request was preferred but had already started, so feel free to close this pull request and reimplement or not. But tests, including new ones, passed. 

**Also wanted to ask if you would be ok with if I incorporated averages and std devs for `peptides.py` statistics for ortholog groups in zol reports in a future version?** I think it might be really interesting to see if the variance for these metrics differs across functionally related ortholog groups.

Kind regards,
Rauf

P.S. Editing because I forgot to attach script to generate plots / distribution percentile cutoffs used in outlier detection function. 
[generate_swissprot_distributions_for_vetting_functions.py](https://github.com/user-attachments/files/22048837/generate_swissprot_distributions_for_vetting_functions.py)